### PR TITLE
Fix payment callbacks

### DIFF
--- a/src/hooks/useEnhancedBookingPayment.tsx
+++ b/src/hooks/useEnhancedBookingPayment.tsx
@@ -152,7 +152,9 @@ export const useEnhancedBookingPayment = () => {
         amount,
         currency,
         customerDetails,
-        bookingReference
+        bookingReference,
+        customOnSuccess,
+        customOnFailure
       );
 
       return true;

--- a/src/hooks/useRazorpayStandardCheckout.tsx
+++ b/src/hooks/useRazorpayStandardCheckout.tsx
@@ -56,7 +56,9 @@ export const useRazorpayStandardCheckout = ({
       email: string;
       phone?: string;
     },
-    bookingReference: string
+    bookingReference: string,
+    onSuccessOverride?: (paymentId: string, orderId: string, signature: string) => void,
+    onFailureOverride?: (error: any) => void
   ) => {
     setIsLoading(true);
 
@@ -120,7 +122,8 @@ export const useRazorpayStandardCheckout = ({
           razorpay_signature: string;
         }) => {
           console.log('Payment successful:', response);
-          onSuccess(
+          const successHandler = onSuccessOverride || onSuccess;
+          successHandler(
             response.razorpay_payment_id,
             response.razorpay_order_id,
             response.razorpay_signature
@@ -129,7 +132,8 @@ export const useRazorpayStandardCheckout = ({
         modal: {
           ondismiss: () => {
             console.log('Payment modal dismissed');
-            onFailure({
+            const failureHandler = onFailureOverride || onFailure;
+            failureHandler({
               code: 'PAYMENT_CANCELLED',
               message: 'Payment was cancelled by user'
             });
@@ -142,7 +146,8 @@ export const useRazorpayStandardCheckout = ({
       
       rzp.on('payment.failed', (response: any) => {
         console.error('Payment failed:', response);
-        onFailure({
+        const failureHandler = onFailureOverride || onFailure;
+        failureHandler({
           code: response.error.code,
           message: response.error.description,
           razorpayOrderId: orderData.orderId


### PR DESCRIPTION
## Summary
- allow overriding success/failure callbacks for Razorpay checkout
- use the overrides in enhanced booking payment hook so payments verify successfully

## Testing
- `npm run lint` *(fails: Unexpected any errors)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_684aa3ccd080833390fa6c5f3b2e44bc