### PR TITLE
Refactor booking payment hook

### DIFF
--- a/src/hooks/useBookingPayment.tsx
+++ b/src/hooks/useBookingPayment.tsx
@@ -1,5 +1,5 @@
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef } from 'react';
 import { useToast } from '@/components/ui/use-toast';
 import { useAuth } from '@/contexts/AuthContext';
 import { UUID, BookingType } from '@/types/booking';
@@ -17,6 +17,17 @@ export const useBookingPayment = () => {
   const [isLoading, setIsLoading] = useState(false);
   const { toast } = useToast();
   const { user } = useAuth();
+
+  const successHandlerRef = useRef<
+    ((paymentId: string, orderId: string, signature: string) => Promise<boolean> | void) | null
+  >(null);
+  const failureHandlerRef = useRef<((error: any) => Promise<boolean> | void) | null>(null);
+
+  const razorpay = useRazorpayPayment({
+    onSuccess: (paymentId, orderId, signature) =>
+      successHandlerRef.current?.(paymentId, orderId, signature),
+    onFailure: (error) => failureHandlerRef.current?.(error)
+  });
   
   const handlePaymentSuccess = async (
     paymentId: string, 
@@ -154,15 +165,10 @@ export const useBookingPayment = () => {
         }
       };
       
-      // Use production Razorpay integration
-      const razorpay = useRazorpayPayment({
-        onSuccess: async (paymentId, orderId, signature) => {
-          return await handlePaymentSuccess(paymentId, orderId, signature, bookingId, bookingType);
-        },
-        onFailure: async (error) => {
-          return await handlePaymentError(error, orderId, bookingId, bookingType);
-        }
-      });
+      successHandlerRef.current = async (paymentId, oid, signature) =>
+        await handlePaymentSuccess(paymentId, oid, signature, bookingId, bookingType);
+      failureHandlerRef.current = async (error) =>
+        await handlePaymentError(error, orderId, bookingId, bookingType);
       
       // Check if Razorpay is ready before processing payment
       if (!razorpay.isReady) {
@@ -190,7 +196,7 @@ export const useBookingPayment = () => {
     } finally {
       setIsLoading(false);
     }
-  }, [user, toast]);
+  }, [user, toast, razorpay]);
 
   return {
     isLoading,


### PR DESCRIPTION
## Summary
- store payment callbacks in refs and set them before calling `useRazorpayPayment`
- invoke `useRazorpayPayment` once in `useBookingPayment`
- call `razorpay.processPayment` with prepared options

## Testing
- `npm run build`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684aa81097e48333bd99569128b46324