### PR TITLE
Enable guest booking payments

### DIFF
--- a/src/pages/BookingPaymentPage.tsx
+++ b/src/pages/BookingPaymentPage.tsx
@@ -174,7 +174,12 @@ const BookingPaymentPage: React.FC = () => {
         'property',
         priceBreakdown.totalAmountDue,
         priceBreakdown.currency,
-        bookingResult.bookingReference
+        bookingResult.bookingReference,
+        !user ? {
+          name: contactInfo.fullName,
+          email: contactInfo.email,
+          phone: contactInfo.phone
+        } : undefined
       );
 
       if (success) {


### PR DESCRIPTION
## Summary
- allow guest bookings to pay by passing contact info
- pass contact info to `useBookingPayment` when user not signed in

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_684aa81e24f08333a6d2bcb8851ec55d