### PR TITLE
Fix checkout navigation path

### DIFF
--- a/src/hooks/useBookingNavigation.tsx
+++ b/src/hooks/useBookingNavigation.tsx
@@ -81,7 +81,7 @@ export const useBookingNavigation = () => {
         });
       }
     } else {
-      // Navigate to checkout first to collect contact info
+      // Navigate to the payment page to collect contact info
       const bookingParams = new URLSearchParams({
         propertyId,
         checkIn: selectedCheckIn.toISOString(),
@@ -92,7 +92,7 @@ export const useBookingNavigation = () => {
         })
       });
 
-      navigate(`/booking/checkout?${bookingParams.toString()}`);
+      navigate(`/booking/payment?${bookingParams.toString()}`);
     }
   };
 


### PR DESCRIPTION
## Summary
- correct the route used for the booking checkout step so it goes to `/booking/payment`
- update the inline comment to match the new navigation target

## Testing
- `npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_684aaa1078f08333be4a81794bf3fedc