### PR TITLE
Add 404 fallback for SPA routing

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,82 @@
+
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Haven Chennai | Unique Container Home Stay by Muttukadu Lake | OMR Retreat</title>
+    <meta name="description" content="Experience sustainable luxury at Haven - a unique container home accommodation beside Muttukadu Lake, Chennai. Eco-friendly lakeside retreat on OMR with curated wellness experiences and nature immersion." />
+    <meta name="keywords" content="container home Chennai, unique stays Muttukadu, lakeside retreat OMR, eco-friendly stay Chennai, wellness experiences Chennai, sustainable accommodation, weekend getaway Chennai" />
+    <meta name="author" content="Haven Chennai" />
+    <meta name="robots" content="index, follow" />
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://havenchennai.com/" />
+    <meta property="og:title" content="Haven Chennai | Unique Container Home Stay by Muttukadu Lake" />
+    <meta property="og:description" content="Experience sustainable luxury at Haven - a unique container home accommodation beside Muttukadu Lake. Eco-friendly lakeside retreat with curated wellness experiences." />
+    <meta property="og:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
+    <meta property="og:site_name" content="Haven Chennai" />
+    <meta property="og:locale" content="en_IN" />
+
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:url" content="https://havenchennai.com/" />
+    <meta name="twitter:title" content="Haven Chennai | Container Home Stay Muttukadu Lake" />
+    <meta name="twitter:description" content="Unique container home accommodation beside Muttukadu Lake. Sustainable lakeside retreat with wellness experiences on Chennai's OMR." />
+    <meta name="twitter:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
+    <meta name="twitter:site" content="@havenchennai" />
+
+    <!-- Local Business Schema -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "LodgingBusiness",
+      "name": "Haven Chennai",
+      "description": "Unique container home accommodation beside Muttukadu Lake offering sustainable luxury and wellness experiences",
+      "url": "https://havenchennai.com",
+      "telephone": "+91-XXXXXXXXXX",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "Padur",
+        "addressLocality": "Chennai",
+        "addressRegion": "Tamil Nadu",
+        "postalCode": "603103",
+        "addressCountry": "IN"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": "12.7925",
+        "longitude": "80.2378"
+      },
+      "amenityFeature": [
+        {"@type": "LocationFeatureSpecification", "name": "Wi-Fi", "value": "500 Mbps"},
+        {"@type": "LocationFeatureSpecification", "name": "Kitchen"},
+        {"@type": "LocationFeatureSpecification", "name": "Parking"},
+        {"@type": "LocationFeatureSpecification", "name": "Lake View"},
+        {"@type": "LocationFeatureSpecification", "name": "Rooftop Deck"}
+      ],
+      "starRating": {
+        "@type": "Rating",
+        "ratingValue": "4.8"
+      },
+      "priceRange": "₹₹"
+    }
+    </script>
+
+    <!-- Canonical URL -->
+    <link rel="canonical" href="https://havenchennai.com/" />
+    
+    <!-- Resource Hints -->
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link rel="preload" as="font" href="/fonts/Montserrat.woff2" type="font/woff2" crossorigin>
+    <link rel="preconnect" href="https://api.lovable.dev">
+  </head>
+
+  <body>
+    <div id="root"></div>
+    <!-- IMPORTANT: DO NOT REMOVE THIS SCRIPT TAG OR THIS VERY COMMENT! -->
+    <script src="https://cdn.gpteng.co/gptengineer.js" type="module"></script>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add `public/404.html` to serve the app for unknown routes

## Testing
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684aac18a96c8333adf0cc1e39367e8b